### PR TITLE
chore: no need for masterSocketServer to start for multiple times at sticky mode

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -51,6 +51,7 @@ class Master extends EventEmitter {
     this.isProduction = isProduction(this.options);
     this.agentWorkerIndex = 0;
     this.closed = false;
+    this.masterSocketServerStarted = false;
     this[REAL_PORT] = this.options.port;
     this[PROTOCOL] = this.options.https ? 'https' : 'http';
 
@@ -273,8 +274,8 @@ class Master extends EventEmitter {
       }
     }
     s = Number(s);
-    const pid = ws[s % workerNumbers];
-    return this.workerManager.getWorker(pid);
+    const workerId = ws[s % workerNumbers];
+    return this.workerManager.getWorker(workerId);
   }
 
   forkAgentWorker() {
@@ -503,9 +504,10 @@ class Master extends EventEmitter {
     address.port = this.options.sticky ? this[REAL_PORT] : address.port;
     this[APP_ADDRESS] = getAddress(address);
 
-    if (this.options.sticky) {
+    if (this.options.sticky && !this.masterSocketServerStarted) {
       this.startMasterSocketServer(err => {
         if (err) return this.ready(err);
+        this.masterSocketServerStarted = true;
         this.ready(true);
       });
     } else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

When there are >1 workers, it seems
https://github.com/eggjs/egg-cluster/blob/74cbb35a8890cdf069f2a98aab288d9804419c70/lib/app_worker.js#L135 
will trigger [onAppStart()](https://github.com/thorseraq/egg-cluster/blob/f49f8a98d843dadba139cc41bd209965282c3fde/lib/master.js#L448) for multiple times, causing `startMasterSocketServer()` duplicated init, how about considering explicitly constraining it?